### PR TITLE
:arrow_up: gofmt and goimports the project.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,41 +1,39 @@
 package api
 
 import (
-	"net/http"
-	"log"
-	"strings"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"encoding/json"
-	"strconv"
-	"os"
-	"github.com/btcsuite/btcd/rpcclient"
-	"time"
-	"io/ioutil"
 	"html/template"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/asdine/storm"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
 	bolt "go.etcd.io/bbolt"
 )
 
-
 type Config struct {
-	Coin				string	`json:"Coin"`
-	Ticker				string	`json:"Ticker"`
-	Daemon				string	`json:"Daemon"`
-	RPCUser				string	`json:"RPCUser"`
-	RPCPassword	 		string	`json:"RPCPassword"`
-	HTTPPostMode		bool
-	DisableTLS			bool
-	EnableCoinCodexAPI 	bool	`json:"EnableCoinCodexAPI"`
-	CapiPort			string	`json:"capi_port"`
+	Coin               string `json:"Coin"`
+	Ticker             string `json:"Ticker"`
+	Daemon             string `json:"Daemon"`
+	RPCUser            string `json:"RPCUser"`
+	RPCPassword        string `json:"RPCPassword"`
+	HTTPPostMode       bool
+	DisableTLS         bool
+	EnableCoinCodexAPI bool   `json:"EnableCoinCodexAPI"`
+	CapiPort           string `json:"capi_port"`
 }
-
-
 
 var Blocks []Block
 
 /// Function to Load Config file from disk as type Config struct
 
-func LoadConfig(file string) (Config) {
+func LoadConfig(file string) Config {
 	// get the local config from disk
 	//filename is the path to the json config file
 
@@ -43,32 +41,31 @@ func LoadConfig(file string) (Config) {
 	configFile, err := os.Open(file)
 	defer configFile.Close()
 	if err != nil {
-		log.Fatal("ERROR: Could not find config file \n GoLang Error:  " , err)
+		log.Fatal("ERROR: Could not find config file \n GoLang Error:  ", err)
 	}
 
 	decoder := json.NewDecoder(configFile)
 	err = decoder.Decode(&config)
 	if err != nil {
-		log.Fatal("ERROR: Could not decode json config  \n GoLang Error:  " , err)
+		log.Fatal("ERROR: Could not decode json config  \n GoLang Error:  ", err)
 	}
 	return config
 }
 
 // config file from disk using loadConfig function
-var configFile  = LoadConfig("./config/config.json")
+var configFile = LoadConfig("./config/config.json")
 
 // coin client using coinClientConfig
 var coinClient, _ = rpcclient.New(coinClientConfig, nil)
 
 // coin client config for coinClient, loads values from configFile
-var coinClientConfig = &rpcclient.ConnConfig {
-	Host: 			configFile.Daemon,
-	User: 			configFile.RPCUser,
-	Pass: 			configFile.RPCPassword,
-	HTTPPostMode:	configFile.HTTPPostMode,
-	DisableTLS:		configFile.DisableTLS,
+var coinClientConfig = &rpcclient.ConnConfig{
+	Host:         configFile.Daemon,
+	User:         configFile.RPCUser,
+	Pass:         configFile.RPCPassword,
+	HTTPPostMode: configFile.HTTPPostMode,
+	DisableTLS:   configFile.DisableTLS,
 }
-
 
 // start the BlockRanger
 func GoBlockRanger() {
@@ -83,23 +80,19 @@ func GoBlockRanger() {
 	startIndex := int64(0)
 	endIndex := int64(blockCount)
 
-	if (blockCount > 500) {
-		endIndex = int64(499);
+	if blockCount > 500 {
+		endIndex = int64(499)
 	}
-	BlockRanger(coinClient, startIndex, endIndex, blockCount);
+	BlockRanger(coinClient, startIndex, endIndex, blockCount)
 
-	log.Println("All Done! Block Hight is ", blockCount)
+	log.Println("All Done! Block Height is ", blockCount)
 }
 
-
-
-
 //GetBlockObject
-func GetBlock(w http.ResponseWriter, r *http.Request)  {
-
+func GetBlock(w http.ResponseWriter, r *http.Request) {
 
 	urlBlock := r.URL.Path
-	if len(urlBlock) > 60{
+	if len(urlBlock) > 60 {
 
 		urlBlock = strings.TrimPrefix(urlBlock, "/block/")
 
@@ -119,11 +112,9 @@ func GetBlock(w http.ResponseWriter, r *http.Request)  {
 			return
 		}
 
-
 		jsonBlock, err := json.Marshal(&block)
 		data := json.RawMessage(jsonBlock)
 		json.NewEncoder(w).Encode(data)
-
 
 	} else {
 		urlBlock = strings.TrimPrefix(urlBlock, "/block/")
@@ -131,7 +122,7 @@ func GetBlock(w http.ResponseWriter, r *http.Request)  {
 
 		blockHeight, err := strconv.ParseInt(urlBlock, 10, 64)
 		if err != nil {
-			log.Println("ERROR: invalid block height specified" + " -- Go Error:" ,err)
+			log.Println("ERROR: invalid block height specified"+" -- Go Error:", err)
 			http.Error(w, "ERROR: invalid block height specified \n"+"Please chose a number like '0' for the genesis block or '444' for block 444", 404)
 			return
 		}
@@ -150,14 +141,11 @@ func GetBlock(w http.ResponseWriter, r *http.Request)  {
 			http.Error(w, "ERROR Getting Block from Block Hash:  "+err.Error(), 500)
 		}
 
-
 		jsonBlock, err := json.Marshal(&block)
 		data := json.RawMessage(jsonBlock)
 		json.NewEncoder(w).Encode(data)
 	}
 }
-
-
 
 //GetTX
 func GetTX(w http.ResponseWriter, r *http.Request) {
@@ -186,15 +174,13 @@ func GetTX(w http.ResponseWriter, r *http.Request) {
 
 }
 
-
-
 //GetBlockchainInfo
 func GetBlockchainInfo(w http.ResponseWriter, r *http.Request) {
 
 	getblockchaininfo, err := coinClient.GetBlockChainInfo()
 	if err != nil {
 		log.Println("ERROR: ", err)
-		http.Error(w, "ERROR: \n"+ err.Error(), 500)
+		http.Error(w, "ERROR: \n"+err.Error(), 500)
 		return
 	}
 
@@ -202,19 +188,17 @@ func GetBlockchainInfo(w http.ResponseWriter, r *http.Request) {
 
 }
 
-
-
 /// CoinCodex.com API for prices
 
 type coincodexapi struct {
-	Symbol 					string	`json:"symbol"`
-	CoinName 				string  `json:"coin_name"`
-	LastPrice				float64	`json:"last_price_usd"`
-	Price_TodayOpenUSD		float64	`json:"today_open"`
-	Price_HighUSD			float64	`json:"price_high_24_usd"`
-	Price_LowUSD			float64	`json:"price_low_24_usd"`
-	Volume24USD				float64	`json:"volume_24_usd"`
-	DataProvider			string	`json:"data_provider"`
+	Symbol             string  `json:"symbol"`
+	CoinName           string  `json:"coin_name"`
+	LastPrice          float64 `json:"last_price_usd"`
+	Price_TodayOpenUSD float64 `json:"today_open"`
+	Price_HighUSD      float64 `json:"price_high_24_usd"`
+	Price_LowUSD       float64 `json:"price_low_24_usd"`
+	Volume24USD        float64 `json:"volume_24_usd"`
+	DataProvider       string  `json:"data_provider"`
 }
 
 func GetCoinCodexData(w http.ResponseWriter, r *http.Request) {
@@ -222,10 +206,10 @@ func GetCoinCodexData(w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 
-		url := "https://coincodex.com/api/coincodex/get_coin/"+configFile.Ticker
+		url := "https://coincodex.com/api/coincodex/get_coin/" + configFile.Ticker
 
 		client := http.Client{
-			Timeout:time.Second * 5, // 5 second timeout
+			Timeout: time.Second * 5, // 5 second timeout
 		}
 
 		request, err := http.NewRequest(http.MethodGet, url, nil)
@@ -245,7 +229,7 @@ func GetCoinCodexData(w http.ResponseWriter, r *http.Request) {
 		}
 
 		jsonData := coincodexapi{
-			DataProvider:"CoinCodex.com",
+			DataProvider: "CoinCodex.com",
 		}
 		jsonError := json.Unmarshal(body, &jsonData)
 		if jsonError != nil {
@@ -257,18 +241,17 @@ func GetCoinCodexData(w http.ResponseWriter, r *http.Request) {
 }
 
 /// To show a simple index page with the coin price info
-func IndexRoute (w http.ResponseWriter, r *http.Request) {
+func IndexRoute(w http.ResponseWriter, r *http.Request) {
 
 	tmpl, err := template.ParseFiles("templates/index.tmpl")
-		if err != nil {
-			log.Println("ERROR: Parsing template file index.tmpl", err)
-		}
+	if err != nil {
+		log.Println("ERROR: Parsing template file index.tmpl", err)
+	}
 
-
-	url := "https://coincodex.com/api/coincodex/get_coin/"+configFile.Ticker
+	url := "https://coincodex.com/api/coincodex/get_coin/" + configFile.Ticker
 
 	client := http.Client{
-		Timeout:time.Second * 5, // 5 second timeout
+		Timeout: time.Second * 5, // 5 second timeout
 	}
 
 	request, err := http.NewRequest(http.MethodGet, url, nil)
@@ -288,7 +271,7 @@ func IndexRoute (w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonData := coincodexapi{
-		DataProvider:"CoinCodex.com",
+		DataProvider: "CoinCodex.com",
 	}
 	jsonError := json.Unmarshal(body, &jsonData)
 	if jsonError != nil {
@@ -298,11 +281,9 @@ func IndexRoute (w http.ResponseWriter, r *http.Request) {
 	tmpl.Execute(w, jsonData)
 }
 
-
-
 /// GetBlock from DB using Height. Couldn't use height has Primary index as bolt doesn't like '0' or block 0
 /// Made my own dbBlock type with it's own "ID"
-func GetBlockFromDBHeight(w http.ResponseWriter, r *http.Request){
+func GetBlockFromDBHeight(w http.ResponseWriter, r *http.Request) {
 
 	db, err := storm.Open("blocks.db", storm.BoltOptions(600, &bolt.Options{Timeout: 5 * time.Second}))
 	if err != nil {
@@ -314,7 +295,7 @@ func GetBlockFromDBHeight(w http.ResponseWriter, r *http.Request){
 
 	var block dbBlock
 	log.Println("Parse Request URL", request)
-	requestInt, err := strconv.ParseUint(request,10, 64)
+	requestInt, err := strconv.ParseUint(request, 10, 64)
 	if err != nil {
 		log.Println("ERROR: cannot parse URL", err)
 		http.Error(w, "ERROR: Could not parse URL \n"+err.Error(), 500)
@@ -331,7 +312,7 @@ func GetBlockFromDBHeight(w http.ResponseWriter, r *http.Request){
 			return
 		}
 	} else {
-		err := db.One("ID",requestInt+1, &block)
+		err := db.One("ID", requestInt+1, &block)
 		if err != nil {
 			log.Println("ERROR: Block not found in DB", err)
 			http.Error(w, "ERROR: Block not found in DB \n"+err.Error(), 404)
@@ -340,7 +321,7 @@ func GetBlockFromDBHeight(w http.ResponseWriter, r *http.Request){
 		}
 	}
 
-	log.Println("DB Request: ", request,  block)
+	log.Println("DB Request: ", request, block)
 	json.NewEncoder(w).Encode(block)
 
 	db.Close()

--- a/api/block_ranger.go
+++ b/api/block_ranger.go
@@ -1,25 +1,26 @@
 package api
 
 import (
-	"github.com/btcsuite/btcd/rpcclient"
 	"log"
-	"strconv"
-	"github.com/asdine/storm"
 	"os"
+	"strconv"
+
+	"github.com/asdine/storm"
+	"github.com/btcsuite/btcd/rpcclient"
 )
 
 // DB Block Struct
 
 type dbBlock struct {
-	ID 				  int64    `json:"-"` /// The Primary Key
-	Hash              string   `storm:"index"`
+	ID                int64  `json:"-"` /// The Primary Key
+	Hash              string `storm:"index"`
 	Confirmations     int64
 	Size              int32
-	StrippedSize  	  int32
-	Weight      	  int32
-	Height            int64    `storm:"index"`
+	StrippedSize      int32
+	Weight            int32
+	Height            int64 `storm:"index"`
 	Version           int32
-	VersionHex  	  string
+	VersionHex        string
 	MerkleRoot        string
 	BlockTransactions []string `storm:"index"`
 	Time              int64
@@ -28,7 +29,6 @@ type dbBlock struct {
 	Difficulty        float64
 	PreviousHash      string
 	NextHash          string
-
 }
 
 // Block struct
@@ -36,11 +36,11 @@ type Block struct {
 	Hash              string   `json:"hash"`
 	Confirmations     int64    `json:"confirmations"`
 	Size              int32    `json:"size"`
-	StrippedSize  	  int32	   `json:"strippedSize"`
-	Weight      	  int32	   `json:"weight"`
+	StrippedSize      int32    `json:"strippedSize"`
+	Weight            int32    `json:"weight"`
 	Height            int64    `json:"height"`
-	Version           int32	   `json:"version"`
-	VersionHex  	  string   `json:"versionHex"`
+	Version           int32    `json:"version"`
+	VersionHex        string   `json:"versionHex"`
 	MerkleRoot        string   `json:"merkleRoot"`
 	BlockTransactions []string `json:"tx"`
 	Time              int64    `json:"time"`
@@ -49,7 +49,6 @@ type Block struct {
 	Difficulty        float64  `json:"difficulty"`
 	PreviousHash      string   `json:"previousBlockHash"`
 	NextHash          string   `json:"nextBlockHash"`
-
 }
 
 type TxRaw struct {
@@ -96,16 +95,15 @@ type ScriptSig struct {
 	Hex string `json:"hex"`
 }
 
-
-func BlockRanger (client *rpcclient.Client, startIndex int64, endIndex int64, blockCount int64) {
+func BlockRanger(client *rpcclient.Client, startIndex int64, endIndex int64, blockCount int64) {
 
 	//For each item (block) in the array index, print block details
-	log.Println("starting block ranger at", strconv.FormatInt(startIndex,10) )
+	log.Println("starting block ranger at", strconv.FormatInt(startIndex, 10))
 
 	logIndex := startIndex
 	blockArray := make([]Block, 500)
 	blockArrayIndex := 0
-	for ; startIndex <= endIndex; startIndex++{
+	for ; startIndex <= endIndex; startIndex++ {
 		blockHash, err := client.GetBlockHash(startIndex)
 		if err != nil {
 			log.Println("Error getting block hash from height ", err)
@@ -133,8 +131,8 @@ func BlockRanger (client *rpcclient.Client, startIndex int64, endIndex int64, bl
 			Difficulty:        block.Difficulty,
 			PreviousHash:      block.PreviousHash,
 			NextHash:          block.NextHash,
-			}
-		blockArrayIndex = blockArrayIndex +1
+		}
+		blockArrayIndex = blockArrayIndex + 1
 
 	}
 	log.Println("Batch completed from:", logIndex, " to ", endIndex)
@@ -143,24 +141,23 @@ func BlockRanger (client *rpcclient.Client, startIndex int64, endIndex int64, bl
 	for _, block := range blockArray {
 
 		dbIndex := block.Height
-		dbIndex	++
+		dbIndex++
 		log.Println(block, dbIndex)
 		WriteBlock(block, dbIndex)
 
 	}
 
-	if (endIndex < blockCount) {
+	if endIndex < blockCount {
 		newEndIndex := int64(0)
-		if ((endIndex + 500) > blockCount) {
+		if (endIndex + 500) > blockCount {
 			newEndIndex = blockCount
 		} else {
 			newEndIndex = endIndex + 500
-		} 
-		BlockRanger(client, endIndex + 1, newEndIndex, blockCount)
+		}
+		BlockRanger(client, endIndex+1, newEndIndex, blockCount)
 	}
 
 }
-
 
 func WriteBlock(block Block, blockArrayIndex int64) {
 
@@ -172,7 +169,7 @@ func WriteBlock(block Block, blockArrayIndex int64) {
 	}
 
 	blockDB := dbBlock{
-		ID:  			   blockArrayIndex,
+		ID:                blockArrayIndex,
 		Hash:              block.Hash,
 		Confirmations:     block.Confirmations,
 		Size:              block.Size,
@@ -203,8 +200,7 @@ func WriteBlock(block Block, blockArrayIndex int64) {
 
 }
 
-func DBChecker (){
-
+func DBChecker() {
 
 	if _, err := os.Stat("blocks.db"); os.IsNotExist(err) {
 		log.Println("Running Block Ranger")

--- a/main.go
+++ b/main.go
@@ -1,24 +1,18 @@
 package main
 
 import (
-
 	"log"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
+
 	"github.com/aciddude/capi/api"
 )
 
-
-var configFile  = api.LoadConfig("./config/config.json")
+var configFile = api.LoadConfig("./config/config.json")
 
 func main() {
-
-
 	api.DBChecker()
-
-
-
-
 
 	router := mux.NewRouter()
 	router.HandleFunc("/block/{HeightOrHash}", api.GetBlock).Methods("GET")
@@ -27,6 +21,7 @@ func main() {
 	router.HandleFunc("/blockchaininfo", api.GetBlockchainInfo).Methods("GET")
 	router.HandleFunc("/blkdb/{Height}", api.GetBlockFromDBHeight).Methods("GET")
 	router.HandleFunc("/", api.IndexRoute).Methods("GET")
+
 	log.Println("capi v0.1 is running!")
 	log.Fatal(http.ListenAndServe(configFile.CapiPort, router))
 }


### PR DESCRIPTION
- Uses canonical go formatter (`gofmt`) to format code.
- Uses `goimports` to organise go imports.

This PR doesn't include the import pathing patch in #3 and will need to be merged in.